### PR TITLE
Add 'caproto' project to table of Implementations.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -56,6 +56,7 @@ Protocol                     Project
 `WebSocket`_                 wsproto_
 `SOCKSv5`_                   socks5_
 `RFC 2217 (Serial over IP)`_ pyserial_
+`EPICS Channel Access`_      caproto_
 ============================ ===========
 
 .. _FastCGI: https://htmlpreview.github.io/?https://github.com/FastCGI-Archives/FastCGI.com/blob/master/docs/FastCGI%20Specification.html
@@ -75,6 +76,8 @@ Protocol                     Project
 .. _socks5: https://github.com/mike820324/socks5
 .. _RFC 2217 (Serial over IP): https://tools.ietf.org/html/rfc2217
 .. _pyserial: https://pythonhosted.org/pyserial/pyserial_api.html#serial.rfc2217.PortManager
+.. _EPICS Channel Access: https://epics.anl.gov/base/R3-16/0-docs/CAproto/index.html
+.. _caproto: https://nsls-ii.github.io/caproto
 
 
 Libraries


### PR DESCRIPTION
Inspired by this effort, I have implemented a sans I/O library for a distributed hardware control protocol used by large experimental facilities (large telescopes, particle accelerators, synchrotrons...). It called [caproto](https://nsls-ii.github.io/caproto/).

Is it appropriate to add it to this list? No hard feelings if this is not merged. :- )