### PR TITLE
Add google-music-proto

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -88,6 +88,8 @@ performing any I/O:
 
   * `ohneio`_ (network protocol parsing; `Getting started <https://ohneio.readthedocs.io/en/latest/getting_started.html#getting-started>`_)
   * gidgethub_ (GitHub API)
+  * google-music-proto_ (Google Music API)
 
 .. _ohneio: https://github.com/acatton/ohneio
 .. _gidgethub: https://gidgethub.readthedocs.io/
+.. _google-music-proto: https://google-music-proto.readthedocs.io/


### PR DESCRIPTION
This should've been released in 2016. Some burnout and a serious bout of anxiety slid it into 2018.
I know this is your month away from the FOSS world. This happens to be my month for jumping back into it.
Hopefully this won't be my last Sans-I/O API wrapper.