### PR TITLE
Add python ssl bio for SSL/TLS

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  builder: html
+  configuration: conf.py

--- a/index.rst
+++ b/index.rst
@@ -65,6 +65,7 @@ Protocol                     Project
 `D-Bus`_                     jeepney_
 `Thorlabs APT`_              thorlabs-apt-protocol_
 `Matrix`_                    matrix-nio_
+`SSL/TLS`_                   cpython_
 ============================ ======================
 
 .. _FastCGI: https://htmlpreview.github.io/?https://github.com/FastCGI-Archives/FastCGI.com/blob/master/docs/FastCGI%20Specification.html
@@ -102,6 +103,8 @@ Protocol                     Project
 .. _thorlabs-apt-protocol: https://gitlab.com/yaq/thorlabs-apt-protocol
 .. _Matrix: https://matrix.org/
 .. _matrix-nio: https://github.com/poljar/matrix-nio
+.. _SSL/TLS: https://tlswg.org/
+.. _cpython: https://docs.python.org/3/library/ssl.html#memory-bio-support
 
 Libraries
 ---------


### PR DESCRIPTION
The standard library offers a first-class sans-io API to SSL/TLS inside the ssl module. It uses the BIO interface of OpenSSL under the hood which explicitly is about managing a SSL/TLS connection with buffers instead of actual network reads/writes.

Even if it is part of the standard library and correctly documented, a "python sans-io tls" query on search engines doesn't immediately yield a result to the standard library and someone clueless (like the author of this commit) can miss it.

A link is now provided inside the protocol list so it can be more easily found.