### PR TITLE
DOC: remove google-music-proto

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -117,8 +117,6 @@ performing any I/O:
 
   * `ohneio`_ (network protocol parsing; `Getting started <https://ohneio.readthedocs.io/en/latest/getting_started.html#getting-started>`_)
   * gidgethub_ (GitHub API)
-  * google-music-proto_ (Google Music API)
 
 .. _ohneio: https://github.com/acatton/ohneio
 .. _gidgethub: https://gidgethub.readthedocs.io/
-.. _google-music-proto: https://google-music-proto.readthedocs.io/


### PR DESCRIPTION
Google shutdown Google Music and this project was made a public archive in Oct 2020.

https://github.com/thebigmunch/google-music-proto